### PR TITLE
feat: Reject `/search` with no filters

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -70,7 +70,7 @@ export default class Search extends Command {
       return;
     }
     // Execute the search
-    const { data: data0, searchURL } = await wscSearchRequest("/search.json", {
+    const { data: searchData, searchURL } = await wscSearchRequest("/search.json", {
       "search": interaction.options.getString("query"),
       "category": interaction.options.getString("category"),
       "players": (interaction.options.getNumber("num_players") && <number>interaction.options.getNumber("num_players") > 0) ? `${interaction.options.getNumber("num_players")}-${interaction.options.getNumber("num_players")}` : null,
@@ -78,7 +78,7 @@ export default class Search extends Command {
       "map": selectedMapObject ? toSlug(selectedMapObject.en) : null,
       "sort": interaction.options.getString("sort")
     });
-    let data = data0;
+    let data = searchData;
 
     // Process the data
     if (!Array.isArray(data)) {
@@ -140,8 +140,8 @@ export default class Search extends Command {
   }
 
   private async wikiSearchSubcommandRun(interaction: Command.ChatInputInteraction) {
-    const { data: data0, searchURL } = await wscSearchRequest(`/wiki/search/${encodeURIComponent(interaction.options.getString("query", true)).replace(".", " ")}.json`);
-    let data = data0;
+    const { data: searchData, searchURL } = await wscSearchRequest(`/wiki/search/${encodeURIComponent(interaction.options.getString("query", true)).replace(".", " ")}.json`);
+    let data = searchData;
 
     // Process the data
     if (!Array.isArray(data)) {

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -12,6 +12,7 @@ import type { ClientRequest } from "http";
 import OllieBotError from "../lib/OllieBotError";
 import { toSlug } from "../lib/utils/string_helper";
 import WorkshopCodesConstants from "../config/constants/workshop-codes-constants";
+import { ExampleSearches } from "../config/constants/example-searches";
 
 export default class Search extends Command {
   public constructor(context: Command.Context, options: Command.Options) {
@@ -70,7 +71,7 @@ export default class Search extends Command {
       return;
     }
     // Execute the search
-    const { data: searchData, searchURL } = await wscSearchRequest("/search.json", {
+    const { data: searchData, searchURL, error } = await wscSearchRequest("/search.json", {
       "search": interaction.options.getString("query"),
       "category": interaction.options.getString("category"),
       "players": (interaction.options.getNumber("num_players") && <number>interaction.options.getNumber("num_players") > 0) ? `${interaction.options.getNumber("num_players")}-${interaction.options.getNumber("num_players")}` : null,
@@ -78,7 +79,13 @@ export default class Search extends Command {
       "map": selectedMapObject ? toSlug(selectedMapObject.en) : null,
       "sort": interaction.options.getString("sort")
     });
+    if (error) {
+      interaction.editReply(error);
+      return;
+    }
     let data = searchData;
+
+
 
     // Process the data
     if (!Array.isArray(data)) {
@@ -140,7 +147,11 @@ export default class Search extends Command {
   }
 
   private async wikiSearchSubcommandRun(interaction: Command.ChatInputInteraction) {
-    const { data: searchData, searchURL } = await wscSearchRequest(`/wiki/search/${encodeURIComponent(interaction.options.getString("query", true)).replace(".", " ")}.json`);
+    const { data: searchData, searchURL, error } = await wscSearchRequest(`/wiki/search/${encodeURIComponent(interaction.options.getString("query", true)).replace(".", " ")}.json`);
+    if (error) {
+      interaction.editReply(error);
+      return;
+    }
     let data = searchData;
 
     // Process the data
@@ -294,7 +305,10 @@ function wscSearchURLFromPathAndParams(path: string, params?: Record<string, str
   return searchURL;
 }
 
-async function wscSearchRequest(path: string, params?: Record<string, string | boolean | null>): Promise<{ data: unknown[], searchURL: URL }> {
+async function wscSearchRequest(path: string, params?: Record<string, string | boolean | null>, errorOnNoParams = true): Promise<{ data: unknown[], searchURL: URL, error?: string }> {
+  if (params && errorOnNoParams && Object.values(params).every((param) => param == null))
+    return { data: [], searchURL: new URL("https://workshop.codes"), error: "It looks like you didn't provide any search options. Please include at least one search filter and try again.\n\nIf you're trying to use search terms or keywords, use the `query` value. For example, `/search codes query:" + ExampleSearches[(Math.random() * ExampleSearches.length) | 0] + "`"};
+
   const searchURL = wscSearchURLFromPathAndParams(path, params);
 
   const response = await axios.get(searchURL.toString())

--- a/src/config/constants/example-searches.ts
+++ b/src/config/constants/example-searches.ts
@@ -1,0 +1,9 @@
+export const ExampleSearches = [
+  "aim trainer",
+  "lava parkour",
+  "ana parkour",
+  "sleep training",
+  "hide and seek",
+  "genji parkour",
+  "dragonblade training"
+];


### PR DESCRIPTION
Since people using the `/search` command are likely not trying to simply fetch an unfiltered list of posts, this PR now explicitly fails an interaction which does not result in any explicit filters.
